### PR TITLE
YALB-350: Tech Debt - move component tokens to tokens repo

### DIFF
--- a/tokens/atoms/cta.yml
+++ b/tokens/atoms/cta.yml
@@ -1,0 +1,19 @@
+color:
+  theme:
+    cta:
+      primary:
+        value: "{color.blue.yale}"
+      secondary:
+        value: "{color.background}"
+  cta:
+    primary:
+      value: "{color.theme.cta.primary}"
+    secondary:
+      value: "{color.theme.cta.secondary}"
+    theme:
+      gray-800:
+        value: true
+      gray-700:
+        value: true
+      blue-yale:
+        value: true

--- a/tokens/atoms/links.yml
+++ b/tokens/atoms/links.yml
@@ -9,3 +9,24 @@ link:
       value: "{size.thickness.2}"
     thick:
       value: "{size.thickness.8}"
+link-themes:
+  "gray-800":
+    link-base:
+      value: "{color.basic.white.value}"
+    link-hover:
+      value: "{color.blue.light.value}"
+  "blue-yale":
+    link-base:
+      value: "{color.basic.white.value}"
+    link-hover:
+      value: "{color.blue.light.value}"
+  "gray-700":
+    link-base:
+      value: "{color.basic.white.value}"
+    link-hover:
+      value: "{color.gray.300.value}"
+  "gray-200":
+    link-base:
+      value: "{color.blue.yale.value}"
+    link-hover:
+      value: "{color.gray.700.value}"

--- a/tokens/atoms/links.yml
+++ b/tokens/atoms/links.yml
@@ -1,32 +1,33 @@
 link:
-  color:
-    base:
-      value: "{color.blue.medium}"
-    hover:
-      value: "{color.gray.700}"
   underline-size:
     default:
       value: "{size.thickness.2}"
     thick:
       value: "{size.thickness.8}"
-link-themes:
-  "gray-800":
-    link-base:
-      value: "{color.basic.white.value}"
-    link-hover:
-      value: "{color.blue.light.value}"
-  "blue-yale":
-    link-base:
-      value: "{color.basic.white.value}"
-    link-hover:
-      value: "{color.blue.light.value}"
-  "gray-700":
-    link-base:
-      value: "{color.basic.white.value}"
-    link-hover:
-      value: "{color.gray.300.value}"
-  "gray-200":
-    link-base:
-      value: "{color.blue.yale.value}"
-    link-hover:
-      value: "{color.gray.700.value}"
+color:
+  link:
+    base:
+      value: "{color.blue.medium}"
+    hover:
+      value: "{color.gray.700}"
+    theme:
+      gray-800:
+        base:
+          value: "{color.basic.white.value}"
+        hover:
+          value: "{color.blue.light.value}"
+      blue-yale:
+        base:
+          value: "{color.basic.white.value}"
+        hover:
+          value: "{color.blue.light.value}"
+      gray-700:
+        base:
+          value: "{color.basic.white.value}"
+        hover:
+          value: "{color.gray.300.value}"
+      gray-200:
+        base:
+          value: "{color.blue.yale.value}"
+        hover:
+          value: "{color.gray.700.value}"

--- a/tokens/base/color.yml
+++ b/tokens/base/color.yml
@@ -1,3 +1,10 @@
+color:
+  background:
+    value: "{color.basic.white}"
+  text:
+    value: "{color.gray.700}"
+  heading:
+    value: "{color.gray.800}"
 component-themes:
   "gray-800":
     background:

--- a/tokens/molecules/social-links.yml
+++ b/tokens/molecules/social-links.yml
@@ -1,0 +1,6 @@
+color:
+  social-links:
+    theme:
+      gray-800: true
+      gray-700: true
+      blue-yale: true


### PR DESCRIPTION
This PR introduces and refactors many component tokens (specifically color ones) so that we can define them here, rather than in the component-library-twig scss files.

This merge will need to be coordinated with the respective component library PR so that nothing "breaks" along the way.