### PR TITLE
YALB-844: Capture "bottom-only" shadow as token

### DIFF
--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -308,6 +308,19 @@
         ],
         "type": "boxShadow"
       },
+      "Level 1 - Bottom Shadow Only": {
+        "value": [
+          {
+            "color": "hsl(0deg 0% 0% / 16%)",
+            "type": "dropShadow",
+            "x": 0,
+            "y": 8,
+            "blur": 6,
+            "spread": -6
+          }
+        ],
+        "type": "boxShadow"
+      },
       "Level 2": {
         "value": [
           {


### PR DESCRIPTION
## [YALB-844: Capture "bottom-only" shadow as token](https://yaleits.atlassian.net/browse/YALB-844)

### Description of work
- Add a token for the bottom-only shadow

### Functional testing steps:
- [ ] Confirm there is a new token for "Bottom Shadow Only"