### PR TITLE
fix(yalb-980): content component-width rem value

### DIFF
--- a/tokens/base/layout.yml
+++ b/tokens/base/layout.yml
@@ -23,9 +23,9 @@ size:
   component-layout:
     width:
       max:
-        value: "100"
-      feature:
         value: "84"
+      feature:
+        value: "80"
       highlight:
         value: "65"
       content:

--- a/tokens/base/layout.yml
+++ b/tokens/base/layout.yml
@@ -29,4 +29,4 @@ size:
       highlight:
         value: "65"
       content:
-        value: "49.375"
+        value: "56"

--- a/tokens/organisms/site-header.yml
+++ b/tokens/organisms/site-header.yml
@@ -51,6 +51,6 @@ site-header-layout:
     justify:
       value: "{layout.flex-position.space-between}"
     align:
-      value: "{layout.flex-position.baseline}"
+      value: "{layout.flex-position.right}"
     flex-direction:
       value: "row"


### PR DESCRIPTION
## [YALB-980: Alignment: Global widths](https://yaleits.atlassian.net/browse/YALB-980)

### Description of work
- Changes rem values for `max` and `feature` widths
- Change `site-header-layout` `right` variables from `baseline` position to: 
```
    align:
      value: "{layout.flex-position.right}" 
```
which fixes an alignment issue with the menu. 