### PR TITLE
fix(yalb-995): change max width value and change 'feature' to 'site'

### DIFF
--- a/tokens/base/layout.yml
+++ b/tokens/base/layout.yml
@@ -23,9 +23,9 @@ size:
   component-layout:
     width:
       max:
+        value: "100"
+      site:
         value: "84"
-      feature:
-        value: "80"
       highlight:
         value: "65"
       content:


### PR DESCRIPTION
## [Alignment: Left align text component](https://yaleits.atlassian.net/browse/YALB-995)

### Description of work
- Changes the `max` token back to `1600px` to use for components link `banner` and `grand-hero` to expand beyond the site width of `1344px`
- Changes the `feature` token to be named `site` instead and changes its value to `1344px` rem equivalent. 