### PR TITLE
feat(YALB): update drop shadow to get rid of generation warning

### DIFF
--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -365,7 +365,7 @@
       "Level 1 - Bottom Shadow Only": {
         "value": [
           {
-            "color": "hsl(0deg 0% 0% / 16%)",
+            "color": "#00000029",
             "type": "dropShadow",
             "x": 0,
             "y": 8,


### PR DESCRIPTION


### Description of work
- Our npm transformer was having a hard time parsing an hsl value and would show an error when running `npm run build` but the value was still rendering properly. It just wasn't being transformed.
