### PR TITLE
Add Whitney Humanities Center color theme

### DIFF
--- a/tokens/base/color.yml
+++ b/tokens/base/color.yml
@@ -249,15 +249,15 @@ global-themes:
       value: "Whitney Humanities Center"
     colors:
       slot-one:
-        value: "{color.whc.plum.value}"
+        value: "{color.purple.plum.value}"
       slot-two:
-        value: "{color.whc.ocean.value}"
+        value: "{color.blue.ocean.value}"
       slot-three:
-        value: "{color.whc.mint.value}"
+        value: "{color.blue.mint.value}"
       slot-four:
-        value: "{color.whc.sand.value}"
+        value: "{color.brown.sand.value}"
       slot-five:
-        value: "{color.whc.mushroom.value}"
+        value: "{color.brown.mushroom.value}"
       slot-six:
         value: "{color.blue.yale.value}"
       slot-seven:

--- a/tokens/base/color.yml
+++ b/tokens/base/color.yml
@@ -224,6 +224,26 @@ global-themes:
         value: "{color.gray.900.value}"
       slot-eight:
         value: "{color.basic.white.value}"
+  "six":
+    label:
+      value: "Whitney Humanities Center"
+    colors:
+      slot-one:
+        value: "{color.whc.plum.value}"
+      slot-two:
+        value: "{color.whc.ocean.value}"
+      slot-three:
+        value: "{color.whc.mint.value}"
+      slot-four:
+        value: "{color.whc.sand.value}"
+      slot-five:
+        value: "{color.whc.mushroom.value}"
+      slot-six:
+        value: "{color.blue.yale.value}"
+      slot-seven:
+        value: "{color.gray.800.value}"
+      slot-eight:
+        value: "{color.basic.white.value}"
 basic-themes:
   "gray-800":
     background:

--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -91,6 +91,28 @@
       }
     },
     "color": {
+      "whc": {
+        "mint": {
+          "value": "#89d0c8",
+          "type": "color"
+        },
+        "ocean": {
+          "value": "#36838e",
+          "type": "color"
+        },
+        "sand": {
+          "value": "#c6bbaa",
+          "type": "color"
+        },
+        "mushroom": {
+          "value": "#866f6e",
+          "type": "color"
+        },
+        "lavender": {
+          "value": "#a4a8d5",
+          "type": "color"
+        }
+      },
       "blue": {
         "yale": {
           "value": "#00356b",
@@ -160,7 +182,7 @@
         }
       },
       "orange": {
-        "peach" : {
+        "peach": {
           "value": "#D6A760",
           "type": "color"
         },

--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -97,7 +97,7 @@
           "type": "color"
         },
         "ocean": {
-          "value": "#36838e",
+          "value": "#347D89",
           "type": "color"
         },
         "sand": {
@@ -108,8 +108,8 @@
           "value": "#866f6e",
           "type": "color"
         },
-        "lavender": {
-          "value": "#a4a8d5",
+        "plum": {
+          "value": "#5C546C",
           "type": "color"
         }
       },

--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -91,25 +91,13 @@
       }
     },
     "color": {
-      "whc": {
-        "mint": {
-          "value": "#89d0c8",
-          "type": "color"
-        },
-        "ocean": {
-          "value": "#347D89",
-          "type": "color"
-        },
+      "brown": {
         "sand": {
           "value": "#c6bbaa",
           "type": "color"
         },
         "mushroom": {
           "value": "#866f6e",
-          "type": "color"
-        },
-        "plum": {
-          "value": "#5C546C",
           "type": "color"
         }
       },
@@ -160,6 +148,14 @@
         },
         "deep-teal": {
           "value": "#314253",
+          "type": "color"
+        },
+        "mint": {
+          "value": "#89d0c8",
+          "type": "color"
+        },
+        "ocean": {
+          "value": "#347D89",
           "type": "color"
         }
       },
@@ -276,6 +272,10 @@
         },
         "visited-light-hover": {
           "value": "#D4C3F9",
+          "type": "color"
+        },
+        "plum": {
+          "value": "#5C546C",
           "type": "color"
         }
       }

--- a/tokens/figma-export/tokens.json
+++ b/tokens/figma-export/tokens.json
@@ -155,7 +155,7 @@
           "type": "color"
         },
         "ocean": {
-          "value": "#347D89",
+          "value": "#336F6A",
           "type": "color"
         }
       },


### PR DESCRIPTION
## Description of work
- Adds color theme for [Whitney Humanities Center](https://whc.yale.edu/).

### Functional testing steps:
- [ ] Import this into https://github.com/yalesites-org/component-library-twig
- [ ] Add `{ value: 'six', title: 'Whitney Humanities Center'},` to [preview.js](https://github.com/yalesites-org/component-library-twig/blob/b46c05b6c478ffd566bc55cd80fc323563221cad/.storybook/preview.js#L52)
- [ ] Visit the config page in Storybook and switch to the Whitney Humanities Center theme
- [ ] Confirm that the colors pass accessibility standards

### For administrative questions, please contact Megan Bygness Bradley at megan@fourkitchens.com
